### PR TITLE
add sleep time to avoid 2 req per second limit

### DIFF
--- a/tap_shopify/streams/base.py
+++ b/tap_shopify/streams/base.py
@@ -2,6 +2,7 @@ import datetime
 import functools
 import math
 import sys
+import time
 
 import backoff
 import pyactiveresource
@@ -90,6 +91,7 @@ class Stream():
         self.results_per_page = Context.get_results_per_page(RESULTS_PER_PAGE)
 
     def get_bookmark(self):
+        time.sleep(0.5)
         bookmark = (singer.get_bookmark(Context.state,
                                         # name is overridden by some substreams
                                         self.name,

--- a/tap_shopify/streams/inventory_items.py
+++ b/tap_shopify/streams/inventory_items.py
@@ -3,6 +3,7 @@ import shopify
 from singer.utils import strftime,strptime_to_utc
 from tap_shopify.streams.base import (Stream, shopify_error_handling)
 from tap_shopify.context import Context
+import time
 
 LOGGER = singer.get_logger()
 
@@ -14,6 +15,7 @@ class InventoryItems(Stream):
 
     @shopify_error_handling
     def get_inventory_items(self, inventory_items_ids):
+        time.sleep(0.5)
         return self.replication_object.find(
             ids=inventory_items_ids,
             limit=RESULTS_PER_PAGE)

--- a/tap_shopify/streams/metafields.py
+++ b/tap_shopify/streams/metafields.py
@@ -1,6 +1,7 @@
 import json
 import shopify
 import singer
+import time
 
 from tap_shopify.context import Context
 from tap_shopify.streams.base import (Stream,
@@ -19,6 +20,7 @@ def get_selected_parents():
 def get_metafields(parent_object, since_id):
     # This call results in an HTTP request - the parent object never has a
     # cache of this data so we have to issue that request.
+    time.sleep(0.5)
     return parent_object.metafields(
         limit=Context.get_results_per_page(RESULTS_PER_PAGE),
         since_id=since_id)


### PR DESCRIPTION
Add sleep time before each request to avoid hitting the 2 requests per second limit.