### PR TITLE
bump tap REST version to 2023-04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires='>=3.5.2',
     py_modules=["tap_shopify"],
     install_requires=[
-        "ShopifyAPI==12.1.0",
+        "ShopifyAPI==12.3.0",
         "singer-python==5.12.1",
     ],
     extras_require={

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -28,7 +28,7 @@ logging.getLogger('backoff').setLevel(logging.CRITICAL)
 def initialize_shopify_client():
     api_key = Context.config.get('access_token', Context.config.get("api_key"))
     shop = Context.config['shop']
-    version = Context.config.get('api_version', '2022-04')
+    version = Context.config.get('api_version', '2023-04')
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
     # Shop.current() makes a call for shop details with provided shop and api_key


### PR DESCRIPTION
# Description of change
Update tap to use Shopify REST API v.2023-04 instead of 2022-04
