### PR TITLE
Add shop ID retrieval via GraphQL for Shopify client initialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     install_requires=[
         "ShopifyAPI==12.7.0",
         "singer-python==5.12.1",
+        "requests==2.32.3"
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         "ShopifyAPI==12.7.0",
         "singer-python==5.12.1",
-        "requests==2.32.3"
+        "requests==2.29.0"
     ],
     extras_require={
         'dev': [

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -25,7 +25,7 @@ SDC_KEYS = {'id': 'integer', 'name': 'string', 'myshopify_domain': 'string'}
 
 logging.getLogger('backoff').setLevel(logging.CRITICAL)
 
-# @shopify_error_handling
+@shopify_error_handling
 def initialize_shopify_client():
     api_key = Context.config.get('access_token') or Context.config.get('api_key')
     if api_key is None:
@@ -212,11 +212,6 @@ def sync():
             continue
 
         LOGGER.info('Syncing stream: %s', stream_id)
-
-        # if stream_id in ["products", "incoming_items", "metafields"]:
-            # shopify.ShopifyResource.activate_session(graphql_session)
-        # else:
-            # shopify.ShopifyResource.activate_session(rest_session)
 
         if not Context.state.get('bookmarks'):
             Context.state['bookmarks'] = {}

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -33,11 +33,46 @@ def initialize_shopify_client():
     version = Context.config.get('api_version', '2024-01')
     session = shopify.Session(shop, version, api_key)
     shopify.ShopifyResource.activate_session(session)
+
+    # Make GraphQL request to get shop details if not in config
+    if not Context.config.get('shop_id'):
+        load_shop_id(shop, api_key)
     graphql_version = Context.config.get('graphql_api_version', '2024-04')
-    graphql_session = shopify.Session(shop, graphql_version, api_key)
+    graphql_session = shopify.Session(Context.config["shop_id"], graphql_version, api_key)
 
     # Shop.current() makes a call for shop details with provided shop and api_key
     return shopify.Shop.current().attributes, session, graphql_session
+
+def load_shop_id(shop, api_key):
+    import requests
+        
+    graphql_url = f"https://{shop}.myshopify.com/admin/api/2024-04/graphql.json"
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-Shopify-Access-Token": api_key
+    }
+    query = """
+    {
+        shop {
+            name
+            id
+        }
+    }
+    """
+    
+    response = requests.post(
+        graphql_url,
+        headers=headers,
+        json={"query": query}
+    )
+    
+    if hasattr(response, 'url'):
+        # Extract shop ID from response URL
+        shop_url = response.url
+        Context.config['shop_id'] = shop_url.split('/')[2].split('.')[0]
+    else:
+        LOGGER.warning("Failed to fetch shop details via GraphQL: %s", response.text)
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)

--- a/tap_shopify/__init__.py
+++ b/tap_shopify/__init__.py
@@ -45,8 +45,6 @@ def initialize_shopify_client():
     return shopify.Shop.current().attributes, session, graphql_session
 
 def load_shop_id(shop, api_key):
-    import requests
-
     graphql_url = f"https://{shop}.myshopify.com/admin/api/2024-04/graphql.json"
     headers = {
         "Accept": "application/json",

--- a/tap_shopify/streams/incoming_items.py
+++ b/tap_shopify/streams/incoming_items.py
@@ -28,14 +28,16 @@ class IncomingItems(Stream):
 
     @shopify_error_handling
     def call_api_for_incoming_items(self, parent_object):
+        shopify.ShopifyResource.activate_session(Context.shopify_graphql_session)
         gql_client = shopify.GraphQL()
         with HiddenPrints():
             response = gql_client.execute(self.gql_query, dict(id=parent_object.admin_graphql_api_id))
         res = json.loads(response)
+        shopify.ShopifyResource.activate_session(Context.shopify_rest_session)
         if "error" in res:
             raise Exception(res)
-        return res 
-    
+        return res
+
     def get_objects(self):
         selected_parent = Context.stream_objects['inventory_levels']()
         selected_parent.name = "inventory_levels"

--- a/tap_shopify/streams/products.py
+++ b/tap_shopify/streams/products.py
@@ -166,7 +166,7 @@ class Products(Stream):
         }
     """
 
-    # @shopify_error_handling
+    @shopify_error_handling
     def _call_api(self, query, variables):
         """
         Generalized method for making API calls with a GraphQL client.

--- a/tap_shopify/streams/products.py
+++ b/tap_shopify/streams/products.py
@@ -166,14 +166,16 @@ class Products(Stream):
         }
     """
 
-    @shopify_error_handling
+    # @shopify_error_handling
     def _call_api(self, query, variables):
         """
         Generalized method for making API calls with a GraphQL client.
         """
+        shopify.ShopifyResource.activate_session(Context.shopify_graphql_session)
         gql_client = shopify.GraphQL()
         response = gql_client.execute(query, variables)
         result = json.loads(response)
+        shopify.ShopifyResource.activate_session(Context.shopify_rest_session)
         if result.get("errors"):
             raise Exception(result['errors'])
         return result


### PR DESCRIPTION
- Implement `load_shop_id` function to fetch shop ID dynamically via GraphQL
- Update `initialize_shopify_client` to use shop ID for GraphQL session
- Add fallback mechanism to handle shop ID retrieval when not present in config