### PR TITLE
HGI-7106: Infer `inventory_management` on variant

### DIFF
--- a/tap_shopify/streams/compatibility/product_compatibility.py
+++ b/tap_shopify/streams/compatibility/product_compatibility.py
@@ -63,6 +63,12 @@ class ProductCompatibility(CompatibilityMixin):
                     variant[key] = key_map[value]
         return variant
 
+    def _infer_inventory_management(self, inventory_item):
+        if inventory_item["tracked"]:
+            return "shopify"
+        else:
+            return None
+
     def _convert_variants(self):
         return [
             dict(
@@ -76,7 +82,7 @@ class ProductCompatibility(CompatibilityMixin):
                     "id": self._extract_int_id(variant["id"]),
                     "image_id": self._extract_int_id(variant["image"]["id"]) if variant.get("image") else None,
                     "inventory_item_id": self._extract_int_id(variant["inventoryItem"]["id"]),
-                    "inventory_management": None,  # No longer supported by GraphQL API
+                    "inventory_management": self._infer_inventory_management(variant["inventoryItem"]),
                     "inventory_policy": variant["inventoryPolicy"],
                     "inventory_quantity": variant["inventoryQuantity"],
                     "old_inventory_quantity": None,  # No longer supported by GraphQL API

--- a/tap_shopify/streams/products.py
+++ b/tap_shopify/streams/products.py
@@ -67,6 +67,7 @@ class Products(Stream):
                             inventoryItem {
                                 id
                                 requiresShipping
+                                tracked
                             }
                             createdAt
                             barcode


### PR DESCRIPTION
A small change to infer the inventory_management field that was previously being reported by the REST API.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
