### PR TITLE
HGI-7165: Check for `read_locations` scope before executing Product query

### DIFF
--- a/tap_shopify/streams/compatibility/product_compatibility.py
+++ b/tap_shopify/streams/compatibility/product_compatibility.py
@@ -79,7 +79,7 @@ class ProductCompatibility(CompatibilityMixin):
         ]
 
     def _extract_fulfillment_service(self, inventory_item):
-        inventory_levels = inventory_item["inventoryLevels"].get("nodes", [])
+        inventory_levels = inventory_item.get("inventoryLevels", {}).get("nodes", [])
         if len(inventory_levels) <= 0:
             return
         fulfillment_service = inventory_levels[0]["location"]["fulfillmentService"]

--- a/tap_shopify/streams/products.py
+++ b/tap_shopify/streams/products.py
@@ -298,7 +298,6 @@ class Products(Stream):
         Args:
             query: The GraphQL query to execute
             variables: Variables to pass to the query
-            error_handler: Optional function to handle errors (defaults to self._handle_error)
         """
         shopify.ShopifyResource.activate_session(Context.shopify_graphql_session)
         gql_client = shopify.GraphQL()
@@ -306,8 +305,7 @@ class Products(Stream):
         result = json.loads(response)
         shopify.ShopifyResource.activate_session(Context.shopify_rest_session)
         if result.get("errors"):
-            error_handler = error_handler or self._handle_error
-            error_handler(result['errors'])
+            raise Exception(result['errors'])
         return result
 
     def get_access_scopes(self):


### PR DESCRIPTION

# Description of change

`read_locations` scope  is a new requirement as of GraphQL API v2024-07 to fetch the "fulfillment_service" key for a variant. Here we introduce logic to fetch scopes. If the read_locations scope is not granted, we will log a warning message, and continue the sync without pulling this field.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
