### PR TITLE
HGI-9477 | Added handling for ConnectionResetError / RemoteDisconnect GraphQL (http) error. 

### DIFF
--- a/tap_shopify/graph_ql.py
+++ b/tap_shopify/graph_ql.py
@@ -1,9 +1,7 @@
-from http.client import RemoteDisconnected
 import shopify
 from six.moves import urllib
 import json
 from tap_shopify.exceptions import RetryableAPIError
-import random
 
 import singer
 LOGGER = singer.get_logger()

--- a/tap_shopify/graph_ql.py
+++ b/tap_shopify/graph_ql.py
@@ -1,7 +1,9 @@
+from http.client import RemoteDisconnected
 import shopify
 from six.moves import urllib
 import json
 from tap_shopify.exceptions import RetryableAPIError
+import random
 
 import singer
 LOGGER = singer.get_logger()
@@ -34,6 +36,8 @@ class GraphQL:
                 raise RetryableAPIError(e)
             raise e from e
         except urllib.error.URLError as e:
+            raise RetryableAPIError(e)
+        except ConnectionResetError as e:
             raise RetryableAPIError(e)
 
 


### PR DESCRIPTION
Added handling for ConnectionResetError / RemoteDisconnect error. After these errors, GraphQL requests are retried. The errors were previously fatal.