### PR TITLE
HGI-9705: add pagination and threads to Product Variants

### DIFF
--- a/tap_shopify/graph_ql.py
+++ b/tap_shopify/graph_ql.py
@@ -29,8 +29,8 @@ class GraphQL:
             response = urllib.request.urlopen(req)
             return response.read().decode("utf-8")
         except urllib.error.HTTPError as e:
-            if e.status >= 500 or e.status in [429]:
-                LOGGER.info("Received %s -- backing off", e.status)
+            if e.code == 429 or e.code >= 500:
+                LOGGER.info("Received %s -- backing off", e.code)
                 raise RetryableAPIError(e)
             raise e from e
         except urllib.error.URLError as e:
@@ -38,4 +38,28 @@ class GraphQL:
         except ConnectionResetError as e:
             raise RetryableAPIError(e)
 
-
+    @staticmethod
+    def execute_with_context(endpoint, headers, query, variables=None, operation_name=None):
+        """
+        Execute a GraphQL request using pre-fetched endpoint and headers.
+        Thread-safe: does not read or modify the global Shopify session.
+        Raises RetryableAPIError for 429, 5xx, URLError, ConnectionResetError.
+        Returns the response body as a string.
+        """
+        default_headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        merged = dict(default_headers)
+        merged.update(headers)
+        data = {"query": query, "variables": variables, "operationName": operation_name}
+        req = urllib.request.Request(endpoint, json.dumps(data).encode("utf-8"), merged)
+        try:
+            response = urllib.request.urlopen(req)
+            return response.read().decode("utf-8")
+        except urllib.error.HTTPError as e:
+            if e.code == 429 or e.code >= 500:
+                LOGGER.info("Received %s -- backing off", e.code)
+                raise RetryableAPIError(e)
+            raise e from e
+        except urllib.error.URLError as e:
+            raise RetryableAPIError(e)
+        except ConnectionResetError as e:
+            raise RetryableAPIError(e)

--- a/tap_shopify/streams/products.py
+++ b/tap_shopify/streams/products.py
@@ -160,10 +160,12 @@ class Products(Stream):
                         }
                     """
 
+    # Sort key placeholder; replaced at runtime with CREATED_AT or UPDATED_AT to match replication_key
+    _PRODUCT_SORT_KEY_PLACEHOLDER = "SORT_KEY_PLACEHOLDER"
     products_gql_query = (
         """
         query GetProducts($query: String, $cursor: String) {
-            products(first: 50, after: $cursor, query: $query, sortKey: UPDATED_AT) {
+            products(first: 50, after: $cursor, query: $query, sortKey: SORT_KEY_PLACEHOLDER) {
                 nodes {
         """
         + _PRODUCT_NODE_FIELDS
@@ -220,7 +222,7 @@ class Products(Stream):
     products_gql_query_with_fulfillment_service = (
         """
         query GetProducts($query: String, $cursor: String) {
-            products(first: 20, after: $cursor, query: $query) {
+            products(first: 20, after: $cursor, query: $query, sortKey: SORT_KEY_PLACEHOLDER) {
                 nodes {
         """
         + _PRODUCT_NODE_FIELDS
@@ -337,6 +339,10 @@ class Products(Stream):
         else:
             self.replication_key = "updated_at"
 
+    def _get_product_sort_key(self):
+        """Return GraphQL ProductSortKey matching replication_key so paging order is consistent."""
+        return "CREATED_AT" if self.replication_key == "created_at" else "UPDATED_AT"
+
     @shopify_error_handling
     def _call_api(self, query, variables):
         """
@@ -392,10 +398,17 @@ class Products(Stream):
             "query": query,
             "cursor": cursor
         }
+        sort_key = self._get_product_sort_key()
         if self.has_access_scope('read_locations'):
-            return self._call_api(self.products_gql_query_with_fulfillment_service, variables)
+            gql_query = self.products_gql_query_with_fulfillment_service.replace(
+                self._PRODUCT_SORT_KEY_PLACEHOLDER, sort_key
+            )
+            return self._call_api(gql_query, variables)
         else:
-            return self._call_api(self.products_gql_query, variables)
+            gql_query = self.products_gql_query.replace(
+                self._PRODUCT_SORT_KEY_PLACEHOLDER, sort_key
+            )
+            return self._call_api(gql_query, variables)
 
     def _get_graphql_context(self):
         """Return (endpoint, headers) for thread-safe GraphQL calls without global session."""

--- a/tap_shopify/streams/products.py
+++ b/tap_shopify/streams/products.py
@@ -3,6 +3,8 @@ from tap_shopify.streams.base import (Stream, shopify_error_handling)
 from tap_shopify.context import Context
 import json
 from datetime import timedelta
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import time
 import singer
 from singer.utils import strftime
 from tap_shopify.streams.compatibility.product_compatibility import ProductCompatibility
@@ -10,16 +12,15 @@ from tap_shopify.streams.compatibility.metafield_compatibility import MetafieldC
 from tap_shopify.streams.compatibility.product_category_compatibility import ProductCategoryCompatibility
 from tap_shopify.graph_ql import GraphQL
 
+
 LOGGER = singer.get_logger()
 
 class Products(Stream):
     name = 'products'
     replication_object = shopify.Product
 
-    products_gql_query = """
-        query GetProducts($query: String, $cursor: String) {
-            products(first: 20, after: $cursor, query: $query) {
-                nodes {
+    # Reusable GraphQL fragments for product/variant queries
+    _PRODUCT_NODE_FIELDS = """
                     status
                     publishedAt
                     createdAt
@@ -47,23 +48,8 @@ class Products(Stream):
                             width
                         }
                     }
-                    variants(first: 100) {
-                        nodes {
-                            id
-                            title
-                            sku
-                            position
-                            price
-                            compareAtPrice
-                            inventoryPolicy
-                            inventoryQuantity
-                            taxable
-                            taxCode
-                            updatedAt
-                            image {
-                                id
-                            }
-                            inventoryItem {
+                    """
+    _INVENTORY_ITEM_BASE = """
                                 id
                                 requiresShipping
                                 tracked
@@ -73,84 +59,8 @@ class Products(Stream):
                                         value
                                     }
                                 }
-                            }
-                            createdAt
-                            barcode
-                            selectedOptions {
-                                name
-                                value
-                            }
-                            presentmentPrices (first: 30) {
-                                nodes {
-                                    compareAtPrice {
-                                        amount
-                                        currencyCode
-                                    }
-                                    price {
-                                        amount
-                                        currencyCode
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                pageInfo {
-                    hasNextPage
-                    endCursor
-                }
-            }
-        }
-    """
-
-    products_gql_query_with_fulfillment_service = """
-        query GetProducts($query: String, $cursor: String) {
-            products(first: 20, after: $cursor, query: $query) {
-                nodes {
-                    status
-                    publishedAt
-                    createdAt
-                    vendor
-                    updatedAt
-                    descriptionHtml
-                    productType
-                    tags
-                    handle
-                    templateSuffix
-                    title
-                    id
-                    options {
-                        id
-                        name
-                        position
-                        values
-                    }
-                    images(first: 250) {
-                        nodes {
-                            id
-                            altText
-                            src
-                            height
-                            width
-                        }
-                    }
-                    variants(first: 100) {
-                        nodes {
-                            id
-                            title
-                            sku
-                            position
-                            price
-                            compareAtPrice
-                            inventoryPolicy
-                            inventoryQuantity
-                            taxable
-                            taxCode
-                            updatedAt
-                            image {
-                                id
-                            }
-                            inventoryItem {
+                            """
+    _INVENTORY_ITEM_WITH_FULFILLMENT = """
                                 id
                                 requiresShipping
                                 tracked
@@ -169,6 +79,23 @@ class Products(Stream):
                                         value
                                     }
                                 }
+                            """
+    _VARIANT_NODES_BASE = """
+                            id
+                            title
+                            sku
+                            position
+                            price
+                            compareAtPrice
+                            inventoryPolicy
+                            inventoryQuantity
+                            taxable
+                            taxCode
+                            updatedAt
+                            image {
+                                id
+                            }
+                            inventoryItem {""" + _INVENTORY_ITEM_BASE + """
                             }
                             createdAt
                             barcode
@@ -188,8 +115,66 @@ class Products(Stream):
                                     }
                                 }
                             }
+                        """
+    _VARIANT_NODES_WITH_FULFILLMENT = """
+                            id
+                            title
+                            sku
+                            position
+                            price
+                            compareAtPrice
+                            inventoryPolicy
+                            inventoryQuantity
+                            taxable
+                            taxCode
+                            updatedAt
+                            image {
+                                id
+                            }
+                            inventoryItem {""" + _INVENTORY_ITEM_WITH_FULFILLMENT + """
+                            }
+                            createdAt
+                            barcode
+                            selectedOptions {
+                                name
+                                value
+                            }
+                            presentmentPrices (first: 30) {
+                                nodes {
+                                    compareAtPrice {
+                                        amount
+                                        currencyCode
+                                    }
+                                    price {
+                                        amount
+                                        currencyCode
+                                    }
+                                }
+                            }
+                        """
+    _VARIANTS_PAGE_INFO = """
                         }
-                    }
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
+                    """
+
+    products_gql_query = (
+        """
+        query GetProducts($query: String, $cursor: String) {
+            products(first: 50, after: $cursor, query: $query, sortKey: UPDATED_AT) {
+                nodes {
+        """
+        + _PRODUCT_NODE_FIELDS
+        + """
+                    variants(first: 10, sortKey: ID) {
+                        nodes {
+        """
+        + _VARIANT_NODES_BASE
+        + _VARIANTS_PAGE_INFO
+        + """
+                }
                 }
                 pageInfo {
                     hasNextPage
@@ -198,6 +183,64 @@ class Products(Stream):
             }
         }
     """
+    )
+
+    product_variants_gql_query = (
+        """
+        query GetProductVariants($id: ID!, $variantsCursor: String) {
+            product(id: $id) {
+                variants(first: 150, after: $variantsCursor, sortKey: ID) {
+                    nodes {
+        """
+        + _VARIANT_NODES_BASE
+        + _VARIANTS_PAGE_INFO
+        + """
+                }
+            }
+        }
+    """
+    )
+
+    product_variants_gql_query_with_fulfillment_service = (
+        """
+        query GetProductVariants($id: ID!, $variantsCursor: String) {
+            product(id: $id) {
+                variants(first: 100, after: $variantsCursor, sortKey: ID) {
+                    nodes {
+        """
+        + _VARIANT_NODES_WITH_FULFILLMENT
+        + _VARIANTS_PAGE_INFO
+        + """
+                }
+            }
+        }
+    """
+    )
+
+    products_gql_query_with_fulfillment_service = (
+        """
+        query GetProducts($query: String, $cursor: String) {
+            products(first: 20, after: $cursor, query: $query) {
+                nodes {
+        """
+        + _PRODUCT_NODE_FIELDS
+        + """
+                    variants(first: 10, sortKey: ID) {
+                        nodes {
+        """
+        + _VARIANT_NODES_WITH_FULFILLMENT
+        + _VARIANTS_PAGE_INFO
+        + """
+                }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    """
+    )
 
     products_category_gql_query = """
         query GetProducts($query: String, $cursor: String) {
@@ -354,6 +397,46 @@ class Products(Stream):
         else:
             return self._call_api(self.products_gql_query, variables)
 
+    def _get_graphql_context(self):
+        """Return (endpoint, headers) for thread-safe GraphQL calls without global session."""
+        shopify.ShopifyResource.activate_session(Context.shopify_graphql_session)
+        endpoint = shopify.ShopifyResource.get_site() + "/graphql.json"
+        headers = dict(shopify.ShopifyResource.get_headers())
+        shopify.ShopifyResource.activate_session(Context.shopify_rest_session)
+        headers.setdefault("Accept", "application/json")
+        headers.setdefault("Content-Type", "application/json")
+        return (endpoint, headers)
+
+    @shopify_error_handling
+    def _call_graphql_direct(self, endpoint, headers, query, variables, max_throttle_retries=5):
+        """Execute GraphQL with pre-fetched (endpoint, headers). Uses GraphQL.execute_with_context + THROTTLED retry."""
+        for attempt in range(max_throttle_retries + 1):
+            response_str = GraphQL.execute_with_context(endpoint, headers, query, variables)
+            result = json.loads(response_str)
+            if not result.get("errors"):
+                return result
+            err = result["errors"][0]
+            if err.get("extensions", {}).get("code") == "THROTTLED" and attempt < max_throttle_retries:
+                LOGGER.info("GraphQL throttled, waiting 2s before retry (%s/%s)", attempt + 1, max_throttle_retries)
+                time.sleep(2)
+                continue
+            raise Exception(result["errors"])
+
+    def get_product_variants(self, product_id, variants_cursor=None, graphql_context=None):
+        variables = {
+            "id": product_id,
+            "variantsCursor": variants_cursor
+        }
+        query = (
+            self.product_variants_gql_query_with_fulfillment_service
+            if self.has_access_scope("read_locations")
+            else self.product_variants_gql_query
+        )
+        if graphql_context is not None:
+            endpoint, headers = graphql_context
+            return self._call_graphql_direct(endpoint, headers, query, variables)
+        return self._call_api(query, variables)
+
     def paginate(self, fetch_page, updated_at_min, updated_at_max, process_item, item_type):
         """
         Generic pagination logic for fetching and processing paginated results.
@@ -448,6 +531,33 @@ class Products(Stream):
             updated_at_min = updated_at_max
             self.update_bookmark(strftime(updated_at_min))
 
+    def _has_next_page_variants(self, product):
+        return product.get("variants", {}).get("pageInfo", {}).get("hasNextPage", False)
+
+    def _expand_product_variants(self, product, graphql_context=None):
+        """Fetch all variant pages for one product; returns product with variants expanded (same format)."""
+        variant_nodes = list(product.get("variants", {}).get("nodes", []))
+        has_next_page = self._has_next_page_variants(product)
+        variants_page_count = 0
+        while has_next_page:
+            variants_cursor = product["variants"]["pageInfo"]["endCursor"]
+            variants_page_count += 1
+            LOGGER.info(
+                "Product %s has additional variants, fetching page %s with cursor %s",
+                product["id"],
+                variants_page_count,
+                variants_cursor,
+            )
+            variants_page = self.get_product_variants(
+                product["id"], variants_cursor, graphql_context=graphql_context
+            )
+            product_variants = variants_page["data"]["product"]["variants"]
+            variant_nodes.extend(product_variants.get("nodes", []))
+            product["variants"] = product_variants
+            has_next_page = self._has_next_page_variants(product)
+        product["variants"] = {"nodes": variant_nodes}
+        return product
+
     def get_objects(self):
         # read_locations is a new requirement as of GraphQL API v2024-07 to fetch the "fulfillment_service" key for a variant.
         # This logic of fetching scopes is used to support existing tenants who may not have been granted the read_locations scope.
@@ -456,23 +566,57 @@ class Products(Stream):
         if not self.has_access_scope('read_locations'):
             LOGGER.warning("The `read_locations` access scope is not granted. The `fulfillment_service` field will not be available for product variants")
 
-        def process_product(product):
-            yield ProductCompatibility(product)
-
+        max_workers = int(Context.config.get("variant_fetch_workers", 8))
         updated_at_min = self.get_bookmark()
         stop_time = singer.utils.now().replace(microsecond=0)
         date_window_size = float(Context.config.get("date_window_size", 1))
 
         while updated_at_min < stop_time:
             updated_at_max = min(updated_at_min + timedelta(days=date_window_size), stop_time)
+            cursor = None
+            page_count = 0
 
-            yield from self.paginate(
-                fetch_page=self.get_products,
-                updated_at_min=updated_at_min,
-                updated_at_max=updated_at_max,
-                process_item=process_product,
-                item_type="products"
-            )
+            while True:
+                log_message = f"Fetching products updated between {updated_at_min} and {updated_at_max}, page {page_count}"
+                if cursor:
+                    log_message += f" with cursor {cursor}"
+                LOGGER.info(log_message)
+
+                page = self.get_products(updated_at_min, updated_at_max, cursor)
+                items = page["data"]["products"]["nodes"]
+                page_info = page["data"]["products"]["pageInfo"]
+
+                if not items:
+                    if page_info["hasNextPage"]:
+                        cursor = page_info["endCursor"]
+                        page_count += 1
+                        continue
+                    break
+
+                graphql_context = self._get_graphql_context()
+                if max_workers <= 1:
+                    for product in items:
+                        expanded = self._expand_product_variants(product, graphql_context)
+                        yield ProductCompatibility(expanded)
+                else:
+                    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                        futures = {
+                            executor.submit(self._expand_product_variants, p, graphql_context): i
+                            for i, p in enumerate(items)
+                        }
+                        results = [None] * len(items)
+                        for future in as_completed(futures):
+                            idx = futures[future]
+                            results[idx] = future.result()
+                        for expanded in results:
+                            yield ProductCompatibility(expanded)
+
+                if page_info["hasNextPage"]:
+                    cursor = page_info["endCursor"]
+                    page_count += 1
+                else:
+                    break
+
             updated_at_min = updated_at_max
             self.update_bookmark(strftime(updated_at_min))
 

--- a/tap_shopify/streams/products.py
+++ b/tap_shopify/streams/products.py
@@ -19,8 +19,13 @@ class Products(Stream):
     name = 'products'
     replication_object = shopify.Product
 
-    # Reusable GraphQL fragments for product/variant queries
-    _PRODUCT_NODE_FIELDS = """
+    # Sort key placeholder; replaced at runtime with CREATED_AT or UPDATED_AT to match replication_key
+    _PRODUCT_SORT_KEY_PLACEHOLDER = "SORT_KEY_PLACEHOLDER"
+
+    products_gql_query = """
+        query GetProducts($query: String, $cursor: String) {
+            products(first: 50, after: $cursor, query: $query, sortKey: SORT_KEY_PLACEHOLDER) {
+                nodes {
                     status
                     publishedAt
                     createdAt
@@ -48,8 +53,23 @@ class Products(Stream):
                             width
                         }
                     }
-                    """
-    _INVENTORY_ITEM_BASE = """
+                    variants(first: 10, sortKey: ID) {
+                        nodes {
+                            id
+                            title
+                            sku
+                            position
+                            price
+                            compareAtPrice
+                            inventoryPolicy
+                            inventoryQuantity
+                            taxable
+                            taxCode
+                            updatedAt
+                            image {
+                                id
+                            }
+                            inventoryItem {
                                 id
                                 requiresShipping
                                 tracked
@@ -59,8 +79,88 @@ class Products(Stream):
                                         value
                                     }
                                 }
-                            """
-    _INVENTORY_ITEM_WITH_FULFILLMENT = """
+                            }
+                            createdAt
+                            barcode
+                            selectedOptions {
+                                name
+                                value
+                            }
+                            presentmentPrices (first: 30) {
+                                nodes {
+                                    compareAtPrice {
+                                        amount
+                                        currencyCode
+                                    }
+                                    price {
+                                        amount
+                                        currencyCode
+                                    }
+                                }
+                            }
+                        }
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+    """
+
+    products_gql_query_with_fulfillment_service = """
+        query GetProducts($query: String, $cursor: String) {
+            products(first: 20, after: $cursor, query: $query, sortKey: SORT_KEY_PLACEHOLDER) {
+                nodes {
+                    status
+                    publishedAt
+                    createdAt
+                    vendor
+                    updatedAt
+                    descriptionHtml
+                    productType
+                    tags
+                    handle
+                    templateSuffix
+                    title
+                    id
+                    options {
+                        id
+                        name
+                        position
+                        values
+                    }
+                    images(first: 250) {
+                        nodes {
+                            id
+                            altText
+                            src
+                            height
+                            width
+                        }
+                    }
+                    variants(first: 10, sortKey: ID) {
+                        nodes {
+                            id
+                            title
+                            sku
+                            position
+                            price
+                            compareAtPrice
+                            inventoryPolicy
+                            inventoryQuantity
+                            taxable
+                            taxCode
+                            updatedAt
+                            image {
+                                id
+                            }
+                            inventoryItem {
                                 id
                                 requiresShipping
                                 tracked
@@ -79,23 +179,6 @@ class Products(Stream):
                                         value
                                     }
                                 }
-                            """
-    _VARIANT_NODES_BASE = """
-                            id
-                            title
-                            sku
-                            position
-                            price
-                            compareAtPrice
-                            inventoryPolicy
-                            inventoryQuantity
-                            taxable
-                            taxCode
-                            updatedAt
-                            image {
-                                id
-                            }
-                            inventoryItem {""" + _INVENTORY_ITEM_BASE + """
                             }
                             createdAt
                             barcode
@@ -115,68 +198,12 @@ class Products(Stream):
                                     }
                                 }
                             }
-                        """
-    _VARIANT_NODES_WITH_FULFILLMENT = """
-                            id
-                            title
-                            sku
-                            position
-                            price
-                            compareAtPrice
-                            inventoryPolicy
-                            inventoryQuantity
-                            taxable
-                            taxCode
-                            updatedAt
-                            image {
-                                id
-                            }
-                            inventoryItem {""" + _INVENTORY_ITEM_WITH_FULFILLMENT + """
-                            }
-                            createdAt
-                            barcode
-                            selectedOptions {
-                                name
-                                value
-                            }
-                            presentmentPrices (first: 30) {
-                                nodes {
-                                    compareAtPrice {
-                                        amount
-                                        currencyCode
-                                    }
-                                    price {
-                                        amount
-                                        currencyCode
-                                    }
-                                }
-                            }
-                        """
-    _VARIANTS_PAGE_INFO = """
                         }
                         pageInfo {
                             hasNextPage
                             endCursor
                         }
-                    """
-
-    # Sort key placeholder; replaced at runtime with CREATED_AT or UPDATED_AT to match replication_key
-    _PRODUCT_SORT_KEY_PLACEHOLDER = "SORT_KEY_PLACEHOLDER"
-    products_gql_query = (
-        """
-        query GetProducts($query: String, $cursor: String) {
-            products(first: 50, after: $cursor, query: $query, sortKey: SORT_KEY_PLACEHOLDER) {
-                nodes {
-        """
-        + _PRODUCT_NODE_FIELDS
-        + """
-                    variants(first: 10, sortKey: ID) {
-                        nodes {
-        """
-        + _VARIANT_NODES_BASE
-        + _VARIANTS_PAGE_INFO
-        + """
-                }
+                    }
                 }
                 pageInfo {
                     hasNextPage
@@ -185,64 +212,131 @@ class Products(Stream):
             }
         }
     """
-    )
 
-    product_variants_gql_query = (
-        """
+    product_variants_gql_query = """
         query GetProductVariants($id: ID!, $variantsCursor: String) {
             product(id: $id) {
                 variants(first: 150, after: $variantsCursor, sortKey: ID) {
                     nodes {
-        """
-        + _VARIANT_NODES_BASE
-        + _VARIANTS_PAGE_INFO
-        + """
+                        id
+                        title
+                        sku
+                        position
+                        price
+                        compareAtPrice
+                        inventoryPolicy
+                        inventoryQuantity
+                        taxable
+                        taxCode
+                        updatedAt
+                        image {
+                            id
+                        }
+                        inventoryItem {
+                            id
+                            requiresShipping
+                            tracked
+                            measurement {
+                                weight {
+                                    unit
+                                    value
+                                }
+                            }
+                        }
+                        createdAt
+                        barcode
+                        selectedOptions {
+                            name
+                            value
+                        }
+                        presentmentPrices (first: 30) {
+                            nodes {
+                                compareAtPrice {
+                                    amount
+                                    currencyCode
+                                }
+                                price {
+                                    amount
+                                    currencyCode
+                                }
+                            }
+                        }
+                    }
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
                 }
             }
         }
     """
-    )
 
-    product_variants_gql_query_with_fulfillment_service = (
-        """
+    product_variants_gql_query_with_fulfillment_service = """
         query GetProductVariants($id: ID!, $variantsCursor: String) {
             product(id: $id) {
                 variants(first: 100, after: $variantsCursor, sortKey: ID) {
                     nodes {
-        """
-        + _VARIANT_NODES_WITH_FULFILLMENT
-        + _VARIANTS_PAGE_INFO
-        + """
+                        id
+                        title
+                        sku
+                        position
+                        price
+                        compareAtPrice
+                        inventoryPolicy
+                        inventoryQuantity
+                        taxable
+                        taxCode
+                        updatedAt
+                        image {
+                            id
+                        }
+                        inventoryItem {
+                            id
+                            requiresShipping
+                            tracked
+                            inventoryLevels(first: 1) {
+                                nodes {
+                                    location {
+                                        fulfillmentService {
+                                            handle
+                                        }
+                                    }
+                                }
+                            }
+                            measurement {
+                                weight {
+                                    unit
+                                    value
+                                }
+                            }
+                        }
+                        createdAt
+                        barcode
+                        selectedOptions {
+                            name
+                            value
+                        }
+                        presentmentPrices (first: 30) {
+                            nodes {
+                                compareAtPrice {
+                                    amount
+                                    currencyCode
+                                }
+                                price {
+                                    amount
+                                    currencyCode
+                                }
+                            }
+                        }
+                    }
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
                 }
             }
         }
     """
-    )
-
-    products_gql_query_with_fulfillment_service = (
-        """
-        query GetProducts($query: String, $cursor: String) {
-            products(first: 20, after: $cursor, query: $query, sortKey: SORT_KEY_PLACEHOLDER) {
-                nodes {
-        """
-        + _PRODUCT_NODE_FIELDS
-        + """
-                    variants(first: 10, sortKey: ID) {
-                        nodes {
-        """
-        + _VARIANT_NODES_WITH_FULFILLMENT
-        + _VARIANTS_PAGE_INFO
-        + """
-                }
-                }
-                pageInfo {
-                    hasNextPage
-                    endCursor
-                }
-            }
-        }
-    """
-    )
 
     products_category_gql_query = """
         query GetProducts($query: String, $cursor: String) {
@@ -257,7 +351,6 @@ class Products(Stream):
                             fullName,
                             isLeaf,
                             isRoot
-
                         }
                     }
                 }
@@ -547,6 +640,60 @@ class Products(Stream):
     def _has_next_page_variants(self, product):
         return product.get("variants", {}).get("pageInfo", {}).get("hasNextPage", False)
 
+    def _process_products_page(self, items, graphql_context, max_workers):
+        """
+        Expand variants for a page of products and yield ProductCompatibility records.
+        Uses a thread pool when max_workers > 1, otherwise processes sequentially.
+        """
+        if max_workers <= 1:
+            for product in items:
+                expanded = self._expand_product_variants(product, graphql_context)
+                yield ProductCompatibility(expanded)
+        else:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = {
+                    executor.submit(self._expand_product_variants, p, graphql_context): i
+                    for i, p in enumerate(items)
+                }
+                results = [None] * len(items)
+                for future in as_completed(futures):
+                    idx = futures[future]
+                    results[idx] = future.result()
+                for expanded in results:
+                    yield ProductCompatibility(expanded)
+
+    def _paginate_products_in_window(self, updated_at_min, updated_at_max, graphql_context, max_workers):
+        """
+        Generator that paginates over product pages within a single date window.
+        Yields ProductCompatibility instances for each product (with variants expanded).
+        """
+        cursor = None
+        page_count = 0
+        while True:
+            log_message = f"Fetching products updated between {updated_at_min} and {updated_at_max}, page {page_count}"
+            if cursor:
+                log_message += f" with cursor {cursor}"
+            LOGGER.info(log_message)
+
+            page = self.get_products(updated_at_min, updated_at_max, cursor)
+            items = page["data"]["products"]["nodes"]
+            page_info = page["data"]["products"]["pageInfo"]
+
+            if not items:
+                if page_info["hasNextPage"]:
+                    cursor = page_info["endCursor"]
+                    page_count += 1
+                    continue
+                return
+
+            yield from self._process_products_page(items, graphql_context, max_workers)
+
+            if page_info["hasNextPage"]:
+                cursor = page_info["endCursor"]
+                page_count += 1
+            else:
+                return
+
     def _expand_product_variants(self, product, graphql_context=None):
         """Fetch all variant pages for one product; returns product with variants expanded (same format)."""
         variant_nodes = list(product.get("variants", {}).get("nodes", []))
@@ -564,7 +711,10 @@ class Products(Stream):
             variants_page = self.get_product_variants(
                 product["id"], variants_cursor, graphql_context=graphql_context
             )
-            product_variants = variants_page["data"]["product"]["variants"]
+            product_data = variants_page.get("data", {}).get("product", {})
+            if product_data is None:
+                break
+            product_variants = product_data.get("variants", {})
             variant_nodes.extend(product_variants.get("nodes", []))
             product["variants"] = product_variants
             has_next_page = self._has_next_page_variants(product)
@@ -579,57 +729,17 @@ class Products(Stream):
         if not self.has_access_scope('read_locations'):
             LOGGER.warning("The `read_locations` access scope is not granted. The `fulfillment_service` field will not be available for product variants")
 
-        max_workers = int(Context.config.get("variant_fetch_workers", 8))
         updated_at_min = self.get_bookmark()
         stop_time = singer.utils.now().replace(microsecond=0)
         date_window_size = float(Context.config.get("date_window_size", 1))
+        max_workers = int(Context.config.get("variant_fetch_workers", 8))
 
         while updated_at_min < stop_time:
             updated_at_max = min(updated_at_min + timedelta(days=date_window_size), stop_time)
-            cursor = None
-            page_count = 0
-
-            while True:
-                log_message = f"Fetching products updated between {updated_at_min} and {updated_at_max}, page {page_count}"
-                if cursor:
-                    log_message += f" with cursor {cursor}"
-                LOGGER.info(log_message)
-
-                page = self.get_products(updated_at_min, updated_at_max, cursor)
-                items = page["data"]["products"]["nodes"]
-                page_info = page["data"]["products"]["pageInfo"]
-
-                if not items:
-                    if page_info["hasNextPage"]:
-                        cursor = page_info["endCursor"]
-                        page_count += 1
-                        continue
-                    break
-
-                graphql_context = self._get_graphql_context()
-                if max_workers <= 1:
-                    for product in items:
-                        expanded = self._expand_product_variants(product, graphql_context)
-                        yield ProductCompatibility(expanded)
-                else:
-                    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                        futures = {
-                            executor.submit(self._expand_product_variants, p, graphql_context): i
-                            for i, p in enumerate(items)
-                        }
-                        results = [None] * len(items)
-                        for future in as_completed(futures):
-                            idx = futures[future]
-                            results[idx] = future.result()
-                        for expanded in results:
-                            yield ProductCompatibility(expanded)
-
-                if page_info["hasNextPage"]:
-                    cursor = page_info["endCursor"]
-                    page_count += 1
-                else:
-                    break
-
+            graphql_context = self._get_graphql_context()
+            yield from self._paginate_products_in_window(
+                updated_at_min, updated_at_max, graphql_context, max_workers
+            )
             updated_at_min = updated_at_max
             self.update_bookmark(strftime(updated_at_min))
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -70,6 +70,11 @@ Number of records to request per API page for REST streams that support it. Inva
 - **Default**: `175` (stream default; some streams use fixed limits such as 100 or 250)
 - **Example**: `100` or `175`
 
+#### `variant_fetch_workers` (integer, optional)
+Maximum number of concurrent workers used when fetching product variants in the **products** stream. Higher values can speed up syncs but increase load on the API.
+- **Default**: `8`
+- **Example**: `4` or `16`
+
 #### `use_created_at_replication_key_for_orders` (boolean, optional)
 When `true`, the **orders** stream uses `created_at` instead of `updated_at` as its replication key. Use this when you want to replicate orders by creation time rather than last update time.
 - **Default**: `false` (orders use `updated_at`)
@@ -124,6 +129,7 @@ All options with sample values:
   "start_date": "2017-01-01T00:00:00Z",
   "date_window_size": 365,
   "results_per_page": 175,
+  "variant_fetch_workers": 8,
   "use_created_at_replication_key_for_orders": false
 }
 ```

--- a/templates/config.json
+++ b/templates/config.json
@@ -10,5 +10,6 @@
   "start_date": "2017-01-01T00:00:00Z",
   "date_window_size": 365,
   "results_per_page": 175,
+  "variant_fetch_workers": 8,
   "use_created_at_replication_key_for_orders": false
 }


### PR DESCRIPTION
- Added pagination for productVariants > we only get 10 variants with the product and paginate separate requests if there are more
- Implemented multi-thread for the variants requests, adding some support functions for that
- Included logic to backoff if requests get throttled
- Added config flag variant_fetch_workers to optionally set the number of workers